### PR TITLE
Draft generic context store definition

### DIFF
--- a/queue_job/fields.py
+++ b/queue_job/fields.py
@@ -70,19 +70,17 @@ class JobEncoder(json.JSONEncoder):
     """Encode Odoo recordsets so that we can later recompose them"""
 
     def _get_record_context(self, obj):
-        context = obj.env.context.copy()
-        return context
+        return obj._job_prepare_context_before_enqueue()
 
     def default(self, obj):
         if isinstance(obj, models.BaseModel):
-            context = self._get_record_context(obj)
             return {
                 "_type": "odoo_recordset",
                 "model": obj._name,
                 "ids": obj.ids,
                 "uid": obj.env.uid,
                 "su": obj.env.su,
-                "context": context,
+                "context": self._get_record_context(obj),
             }
         elif isinstance(obj, datetime):
             return {"_type": "datetime_isoformat", "value": obj.isoformat()}

--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -59,7 +59,6 @@ class DelayableRecordset(object):
         description=None,
         channel=None,
         identity_key=None,
-        keep_context=False,
     ):
         self.recordset = recordset
         self.priority = priority
@@ -68,7 +67,6 @@ class DelayableRecordset(object):
         self.description = description
         self.channel = channel
         self.identity_key = identity_key
-        self.keep_context = keep_context
 
     def __getattr__(self, name):
         if name in self.recordset:
@@ -90,7 +88,6 @@ class DelayableRecordset(object):
                 description=self.description,
                 channel=self.channel,
                 identity_key=self.identity_key,
-                keep_context=self.keep_context,
             )
 
         return delay
@@ -342,7 +339,6 @@ class Job(object):
         description=None,
         channel=None,
         identity_key=None,
-        keep_context=False,
     ):
         """Create a Job and enqueue it in the queue. Return the job uuid.
 
@@ -363,7 +359,6 @@ class Job(object):
             description=description,
             channel=channel,
             identity_key=identity_key,
-            keep_context=keep_context,
         )
         if new_job.identity_key:
             existing = new_job.job_record_with_same_identity_key()
@@ -404,7 +399,6 @@ class Job(object):
         description=None,
         channel=None,
         identity_key=None,
-        keep_context=False,
     ):
         """ Create a Job
 
@@ -429,11 +423,6 @@ class Job(object):
         :param identity_key: A hash to uniquely identify a job, or a function
                              that returns this hash (the function takes the job
                              as argument)
-        :param keep_context: Determine if the current context should be restored.
-                             Set to True to keep entire context.
-                             Possibility to provide a list of keys to keep
-                             from the current context.
-        :type keep_context: :bool or list
         """
         if args is None:
             args = ()
@@ -454,7 +443,6 @@ class Job(object):
         self.recordset = recordset
 
         self.env = env
-        self.keep_context = keep_context
         self.job_model = self.env["queue.job"]
         self.job_model_name = "queue.job"
 
@@ -601,19 +589,11 @@ class Job(object):
                     "method_name": self.method_name,
                     "job_function_id": self.job_config.job_function_id,
                     "channel_method_name": self.job_function_name,
+                    "records": self.recordset,
                     "args": self.args,
                     "kwargs": self.kwargs,
                 }
             )
-            # By default the context is completely reset
-            # (compatibility with previous version).
-            context = {}
-            if self.keep_context:
-                context = self.env.context.copy()
-                if isinstance(self.keep_context, list):
-                    context = {k: context.get(k) for k in self.keep_context}
-            recordset = self.recordset.with_context(context)
-            vals.update({"records": recordset})
 
         vals_from_model = self._store_values_from_model()
         # Sanitize values: make sure you cannot screw core values
@@ -633,17 +613,6 @@ class Job(object):
                 vals = handler(self)
         return vals
 
-    def _get_record_context(self):
-        """
-        Get the context to execute the job
-        """
-        context = {}
-        company_ids = []
-        if self.company_id:
-            company_ids = [self.company_id]
-        context.update({"job_uuid": self.uuid, "allowed_company_ids": company_ids})
-        return context
-
     @property
     def func_string(self):
         model = repr(self.recordset)
@@ -657,8 +626,7 @@ class Job(object):
 
     @property
     def func(self):
-        context = self._get_record_context()
-        recordset = self.recordset.with_context(**context)
+        recordset = self.recordset.with_context(job_uuid=self.uuid)
         return getattr(recordset, self.method_name)
 
     @property

--- a/queue_job/models/base.py
+++ b/queue_job/models/base.py
@@ -44,7 +44,6 @@ class Base(models.AbstractModel):
         description=None,
         channel=None,
         identity_key=None,
-        keep_context=True,
     ):
         """ Return a ``DelayableRecordset``
 
@@ -82,8 +81,6 @@ class Base(models.AbstractModel):
                              the new job will not be added. It is either a
                              string, either a function that takes the job as
                              argument (see :py:func:`..job.identity_exact`).
-        :param keep_context: boolean to set if the current context
-                             should be restored on the recordset (default: True).
         :return: instance of a DelayableRecordset
         :rtype: :class:`odoo.addons.queue_job.job.DelayableRecordset`
 
@@ -111,7 +108,6 @@ class Base(models.AbstractModel):
             description=description,
             channel=channel,
             identity_key=identity_key,
-            keep_context=keep_context,
         )
 
     def _patch_job_auto_delay(self, method_name, context_key=None):
@@ -220,3 +216,22 @@ class Base(models.AbstractModel):
         :return: dictionary for setting job values.
         """
         return {}
+
+    @staticmethod
+    def _job_prepare_context_before_enqueue_keys(self):
+        """Keys to keep in context of stored jobs
+
+        Empty by default for backward compatibility.
+        """
+        return []
+
+    def _job_prepare_context_before_enqueue(self):
+        """Return the context to store in the jobs
+
+        Can be used to keep only safe keys.
+        """
+        return {
+            key: value
+            for key, value in self.env.context
+            if key in self._job_prepare_context_before_enqueue_keys()
+        }


### PR DESCRIPTION
Proposal to store the context, thinking about a migration path to enable storing the context keys by default :

* first step : do not store any key by default, users can override `_job_prepare_context_before_enqueue_keys` in the base model or any model to define the keys to store in the context
* second step : maybe on the next odoo version, set the list of keys to keep

I didn't adapt the tests yet, this is mainly for discussion as of now.